### PR TITLE
Re-run build target install

### DIFF
--- a/ndk-build/scripts/build_jnilib.sh
+++ b/ndk-build/scripts/build_jnilib.sh
@@ -127,6 +127,9 @@ echo "Cargo Flags: ${CARGO_FLAGS}"
 # from mounted volume
 cd /srcroot
 
+# Ensure target is installed in the event rust updated and invalidated it
+rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
+
 # Build rust build!
 cargo build ${CARGO_FLAGS}
 


### PR DESCRIPTION
Rerun adding the target to rust. This ensures that if rust has updated, profile switched, version changed, etc it will ensure the target is still installed.