### PR TITLE
fix: disable mdbook install from docker image

### DIFF
--- a/rust/build/Dockerfile
+++ b/rust/build/Dockerfile
@@ -32,7 +32,7 @@ RUN rustup update $NIGHTLY_VERSION; \
     rustup default $NIGHTLY_VERSION; \
     rustup component add rustfmt clippy
 
-RUN cargo install mdbook
+# RUN cargo install mdbook
 
 # Node and npm
 ENV NODE_VERSION=12.22.6


### PR DESCRIPTION
Update to proc-macro2 broke mdbook for the current nightly, disabling it here so the image can be built.
mdbook is also installed as part of the CI steps so probably isn't required to be here.