### PR TITLE
Refresh docker build for Rust dev image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,6 @@ docker build -t quay.io/tarilabs/rust:1.31 ./rust/slim
 docker build -t quay.io/tarilabs/rust:alpine-1.40 ./rust/alpine/
 docker build -t quay.io/tarilabs/run:alpine-1.40 ./run/alpine/
 # The nightly version
-docker build -t quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-08-18 ./rust/build/
+docker build -t quay.io/tarilabs/rust_tari-build-with-deps:nightly-2021-09-18 ./rust/build/
 # sqlite libraries
 docker build -t quay.io/tarilabs/sqlite-mobile:201911192122 sqlite-mobile/

--- a/rust/build/Dockerfile
+++ b/rust/build/Dockerfile
@@ -1,23 +1,20 @@
 # Build image for the Tari project; includes SQLite, clippy, rustfmt and other development tools
-FROM rust:1.53
+FROM rust:1.56
 
-ARG NIGHTLY_VERSION=nightly-2021-08-18
+ARG NIGHTLY_VERSION=nightly-2021-09-18
 
 # libs contains:
 #    https://www.sqlite.org/2019/sqlite-autoconf-3290000.tar.gz
 ADD libs libs/
 RUN set -eux; \
     apt-key add ./libs/llvm-snapshot.gpg.key; \
-    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list; \
+    echo "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye main" >> /etc/apt/sources.list; \
     apt-get update; \
-    apt-get install -y git build-essential libtool pkg-config autotools-dev autoconf automake cmake uuid-dev \
-    libpcre3-dev libsodium-dev valgrind libncurses5-dev libncursesw5-dev libunwind-dev libsystemd-dev liblz4-dev \
-    libmicrohttpd-dev libssl-dev \
-    libllvm11 llvm-11 llvm-11-dev llvm-11-runtime llvm-11-tools \
-    clang-11 clang-tools-11 libclang-common-11-dev libclang-11-dev libclang1-11 clang-format-11 clangd-11 \
-    libfuzzer-11-dev \
-    libc++-11-dev libc++abi-11-dev \
-    libcap2-bin libicu-dev libbsd-dev
+    apt-get install -y build-essential cmake \
+    libsodium-dev libunwind-dev libsystemd-dev liblz4-dev \
+    libmicrohttpd-dev \
+    clang-format clang-tools clang clangd libc++-dev libc++1 libc++abi-dev libc++abi1 libclang-dev libclang1 liblldb-dev libomp-dev libomp5 lld llvm-dev llvm-runtime llvm \
+    valgrind
 RUN tar xvzf libs/sqlite-autoconf-3360000.tar.gz; \
     cd sqlite-autoconf-3360000; \
     ./configure; \


### PR DESCRIPTION
* Upgraded to Rust 1:56 base image
* Upgrade debian to bullseye
* Upgrade to LLVM 14
* libfuzzer was removed from this build since it doesn't have a llvm-14
  version yet. This should be rectified in the next release